### PR TITLE
[김정현] Sprint4

### DIFF
--- a/assets/JS/errorMessage.js
+++ b/assets/JS/errorMessage.js
@@ -1,0 +1,26 @@
+export const ERROR_MESSAGE = [
+  {
+    type: 'emailEmpty',
+    message: '이메일을 입력해주세요',
+  },
+  {
+    type: 'emailValid',
+    message: '잘못된 이메일 형식입니다.',
+  },
+  {
+    type: 'nickNameEmpty',
+    message: '닉네임을 입력해주세요.',
+  },
+  {
+    type: 'passwordEmpty',
+    message: '비밀번호를 입력해주세요.',
+  },
+  {
+    type: 'passwordValid',
+    message: '비밀번호를 8자 이상 입력해주세요.',
+  },
+  {
+    type: 'passwordIsNotEquals',
+    message: '비밀번호가 일치하지 않습니다',
+  },
+];

--- a/assets/JS/loginValidation.js
+++ b/assets/JS/loginValidation.js
@@ -8,6 +8,7 @@ import {
 let emailInvalid = false;
 let passwordInvalid = false;
 
+const loginForm = document.querySelector('.form');
 const emailInput = document.querySelector('input[type="email"]');
 const passwordInput = document.querySelector('input[type="password"]');
 const passwordHideBtn = document.querySelector('.hide-btn');
@@ -19,17 +20,37 @@ function checkFormButton() {
 }
 // 로그인 버튼 활성화
 
-emailInput.addEventListener('change', e => {
-  const value = e.target.value;
-  emailInvalid = !isEmail(value, emailInput) || isNotEmpty(value, emailInput);
-  checkFormButton();
-});
+function validationEmail() {
+  const value = emailInput.value;
+  emailInvalid = isNotEmpty(value, emailInput, 'emailEmpty');
 
-passwordInput.addEventListener('change', e => {
-  passwordInvalid = hasMinLength(e.target.value, 8, passwordInput);
+  if (emailInvalid) {
+    emailInvalid = isEmail(value, emailInput, 'emailValid');
+  }
+
   checkFormButton();
-});
+}
+// 이메일 검사
+
+function validationPassword() {
+  const value = passwordInput.value;
+  passwordInvalid = isNotEmpty(value, passwordInput, 'passwordEmpty');
+
+  if (passwordInvalid) {
+    passwordInvalid = hasMinLength(value, 8, passwordInput, 'passwordValid');
+  }
+  checkFormButton();
+}
+// 비밀번호 검사
+
+emailInput.addEventListener('blur', validationEmail);
+passwordInput.addEventListener('blur', validationPassword);
 
 passwordHideBtn.addEventListener('click', e => {
   isPasswordHide(passwordHideBtn, passwordInput);
+});
+
+loginForm.addEventListener('submit', e => {
+  e.preventDefault();
+  location.href = '../items.html';
 });

--- a/assets/JS/signupValidation.js
+++ b/assets/JS/signupValidation.js
@@ -10,8 +10,10 @@ let emailInvalid = false;
 let passwordInvalid = false;
 let checkingPasswordInvalid = false;
 let nickNameInvalid = false;
-let passwordValue;
+let passwordValue = '';
+let passwordCheckValue = '';
 
+const signUpForm = document.querySelector('.form');
 const emailInput = document.querySelector('input[type="email"]');
 const nickNameInput = document.querySelector('input[name="nickname"]');
 const passwordInput = document.querySelector('input[type="password"]');
@@ -24,42 +26,72 @@ const passwordHideBtn = showPasswordBtn[0];
 const checkPasswordHideBtn = showPasswordBtn[1];
 
 function checkFormButton() {
-  const loginBtn = document.querySelector('button[type="submit"]');
+  const signUpBtn = document.querySelector('button[type="submit"]');
   const activeLoginBtn =
     emailInvalid &&
     passwordInvalid &&
     checkingPasswordInvalid &&
     nickNameInvalid;
-  loginBtn.disabled = !activeLoginBtn;
+  signUpBtn.disabled = !activeLoginBtn;
 }
 // 회원가입 버튼 활성화
 
-emailInput.addEventListener('change', e => {
+function validationEmail() {
+  const value = emailInput.value;
+  emailInvalid = isNotEmpty(value, emailInput, 'emailEmpty');
+  if (emailInvalid) {
+    emailInvalid = isEmail(value, emailInput, 'emailValid');
+  }
+  checkFormButton();
+}
+
+function validationPassword() {
+  const value = passwordInput.value;
+  passwordValue = value;
+  passwordInvalid = isNotEmpty(value, passwordInput, 'passwordEmpty');
+  if (passwordInvalid) {
+    passwordInvalid = hasMinLength(value, 8, passwordInput, 'passwordValid');
+  }
+  if (passwordInvalid) {
+    checkingPasswordInvalid = isEqualsPassword(
+      passwordValue,
+      passwordCheckValue,
+      passwordCheckInput,
+      'passwordIsNotEquals'
+    );
+  } else {
+    checkingPasswordInvalid = false;
+  }
+  checkFormButton();
+}
+
+emailInput.addEventListener('blur', validationEmail);
+// 이메일 검사
+
+nickNameInput.addEventListener('blur', e => {
   const value = e.target.value;
-  emailInvalid = !isEmail(value, emailInput) || isNotEmpty(value, emailInput);
+  nickNameInvalid = isNotEmpty(value, nickNameInput, 'nickNameEmpty');
+
   checkFormButton();
 });
+// 닉네임 검사
 
-passwordInput.addEventListener('change', e => {
-  passwordInvalid = hasMinLength(e.target.value, 8, passwordInput);
-  passwordValue = e.target.value;
-  checkFormButton();
-});
+passwordInput.addEventListener('blur', validationPassword);
+// 비밀번호 검사
 
-nickNameInput.addEventListener('change', e => {
-  nickNameInvalid = isNotEmpty(e.target.value, nickNameInput);
-  checkFormButton();
-});
-
-passwordCheckInput.addEventListener('change', e => {
+passwordCheckInput.addEventListener('blur', e => {
   const value = e.target.value;
+  passwordCheckValue = value;
   checkingPasswordInvalid = isEqualsPassword(
+    passwordCheckValue,
     passwordValue,
-    value,
-    passwordCheckInput
+    passwordCheckInput,
+    'passwordIsNotEquals'
   );
+
   checkFormButton();
 });
+// 비밀번호 확인
 
 passwordHideBtn.addEventListener('click', () => {
   isPasswordHide(passwordHideBtn, passwordInput);
@@ -67,4 +99,9 @@ passwordHideBtn.addEventListener('click', () => {
 
 checkPasswordHideBtn.addEventListener('click', () => {
   isPasswordHide(checkPasswordHideBtn, passwordCheckInput);
+});
+
+signUpForm.addEventListener('submit', e => {
+  e.preventDefault();
+  location.href = '../signin.html';
 });

--- a/assets/JS/validation.js
+++ b/assets/JS/validation.js
@@ -1,39 +1,57 @@
-function printErrMessage(isValid, inputElement) {
-  const errMsg = inputElement.nextElementSibling;
-  if (isValid) {
-    errMsg.classList.remove('show-msg');
-    inputElement.classList.remove('error');
-  } else {
-    errMsg.classList.add('show-msg');
+import { ERROR_MESSAGE } from './errorMessage.js';
+
+function printErrMessage(isValid, inputElement, type) {
+  const existingErrMsg = inputElement.nextElementSibling;
+
+  if (existingErrMsg && existingErrMsg.classList.contains('error-msg')) {
+    existingErrMsg.remove();
+  }
+
+  const findType = ERROR_MESSAGE.find(msg => msg.type === type);
+  const errorMessage = findType ? findType.message : null;
+  const createErrMsgEl = document.createElement('p');
+
+  if (!isValid) {
     inputElement.classList.add('error');
+    createErrMsgEl.classList.add('error-msg');
+    createErrMsgEl.textContent = errorMessage;
+    inputElement.insertAdjacentElement('afterend', createErrMsgEl);
+  } else {
+    inputElement.classList.remove('error');
   }
 }
 // 에러메세지 출력
 
-export function isEmail(value, inputElement) {
-  const isValid = value.includes('@');
-  printErrMessage(isValid, inputElement);
+export function isEmail(value, inputElement, type) {
+  let isValid = false;
+  let email_regex = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{3,}$/;
+  isValid = email_regex.test(value);
+  const errorType = isValid ? '' : type;
+  printErrMessage(isValid, inputElement, errorType);
   return isValid;
 }
 // 이메일 검사
 
-export function isNotEmpty(value, inputElement) {
+export function isNotEmpty(value, inputElement, type) {
   const isValid = value.trim() !== '';
-  printErrMessage(isValid, inputElement);
+  const errorType = isValid ? '' : type;
+  printErrMessage(isValid, inputElement, errorType);
   return isValid;
 }
 // 이메일,닉네임 검사
 
-export function hasMinLength(value, minLength, inputElement) {
+export function hasMinLength(value, minLength, inputElement, type) {
   const isValid = value.length >= minLength;
-  printErrMessage(isValid, inputElement);
+  const errorType = isValid ? '' : type;
+  printErrMessage(isValid, inputElement, errorType);
   return isValid;
 }
 // 최소 비밀번호 검사
 
-export function isEqualsPassword(value, otherValue, inputElement) {
+export function isEqualsPassword(value, otherValue, inputElement, type) {
   const isValid = value === otherValue;
-  printErrMessage(isValid, inputElement);
+  const errorType = isValid ? '' : type;
+  printErrMessage(isValid, inputElement, errorType);
   return isValid;
 }
 // 비밀번호 일치 검사

--- a/assets/css/register.css
+++ b/assets/css/register.css
@@ -1,13 +1,13 @@
 @charset "uft-8";
 
 #register-header {
-  margin-top: 3.75rem;
-  margin-bottom: 2.5rem;
+  margin-top: 6rem;
+  margin-bottom: 4rem;
 }
 
 .register-logo {
   max-width: 460px;
-  padding: 0 2rem;
+  padding: 0 3.2rem;
   margin: 0 auto;
 }
 
@@ -21,29 +21,28 @@
 }
 
 #register-container {
-  max-width: 44rem;
-  min-height: calc(67.5rem - 14.75rem);
-  padding: 0 2rem;
+  max-width: 70.4rem;
+  min-height: calc(1080px - 236px);
+  padding: 0 3.2rem;
   margin: 0 auto;
 }
 
 .input-box {
-  margin-bottom: 1.5rem;
+  margin-bottom: 2.4rem;
 }
 
 .input-box input {
   width: 100%;
-  line-height: 1.5rem;
-  padding: 1rem 1.5rem;
-  border-radius: 0.625rem;
+  line-height: 2.4rem;
+  padding: 1.6rem 2.4rem;
+  border-radius: 1rem;
   border: none;
-  font-size: 1rem;
+  font-size: 1.6rem;
   font-weight: 400;
   background-color: var(--color-gray100);
 }
 .input-box input.error {
   outline: 1px solid var(--color-red);
-  background-color: #ffb8c4;
 }
 .input-box input:focus {
   outline: 1px solid #3692ff;
@@ -51,9 +50,9 @@
 
 .input-box label {
   display: inline-block;
-  font-size: 1.125rem;
+  font-size: 1.8rem;
   font-weight: 700;
-  margin-bottom: 1rem;
+  margin-bottom: 1.6rem;
 }
 
 .input-password {
@@ -77,30 +76,26 @@
 }
 
 .error-msg {
-  display: none;
-  padding-top: 0.625rem;
-  padding-left: 0.5rem;
+  padding-top: 1rem;
+  padding-left: 1.6rem;
   color: var(--color-red);
-  font-size: 0.875rem;
-  font-weight: 500;
-}
-
-.error-msg.show-msg {
-  display: block;
+  font-size: 1.5rem;
+  font-weight: 600;
+  line-height: 17.9px;
 }
 
 .login-btn {
-  margin-bottom: 1.5rem;
+  margin-bottom: 2.4rem;
 }
 
 .login-btn > button {
   width: 100%;
-  border-radius: 2.5rem;
-  padding: 1rem 0;
+  border-radius: 4rem;
+  padding: 1.6rem 0;
   border: none;
   color: #fff;
   cursor: pointer;
-  font-size: 1.25rem;
+  font-size: 2rem;
   background: var(--color-blue);
 }
 
@@ -112,15 +107,15 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: 1.5rem;
-  padding: 1rem 1.5rem;
+  margin-bottom: 2.4rem;
+  padding: 1.6rem 2.4rem;
   border-radius: 0.5rem;
   background: #e6f2ff;
 }
 
 .login-list {
   display: flex;
-  gap: 1rem;
+  gap: 1.6rem;
 }
 
 .google-login,
@@ -140,6 +135,7 @@
 }
 
 .login-simple {
+  font-size: 1.6rem;
   font-weight: 500;
 }
 
@@ -148,6 +144,7 @@
 }
 
 .register-box > span {
+  font-size: 1.6rem;
   font-weight: 500;
 }
 

--- a/assets/css/reset.css
+++ b/assets/css/reset.css
@@ -14,9 +14,8 @@
 }
 
 html {
-  font-size: 16px;
+  font-size: 62.5%;
 }
-
 /* 여백초기화 */
 body,
 div,

--- a/assets/css/response.css
+++ b/assets/css/response.css
@@ -3,10 +3,10 @@
 @media (max-width: 1199px) {
   /* 메인 페이지 */
   #header {
-    padding: 0 1.5rem;
+    padding: 0 2.4rem;
   }
   .wrapper {
-    padding: 0 1.5rem;
+    padding: 0 2.4rem;
     margin-bottom: 4rem;
   }
   #banner {
@@ -20,7 +20,7 @@
     align-items: center;
   }
   .banner-title > .title {
-    font-size: 2.5rem;
+    font-size: 4rem;
     text-align: center;
     padding-bottom: 24px;
     line-height: 44.8px;
@@ -35,7 +35,7 @@
     right: 0;
   }
   #contents {
-    margin: 1.5rem 0 0 0;
+    margin: 2.4rem 0 0 0;
   }
   .item-list {
     flex-direction: column;
@@ -53,18 +53,18 @@
     padding: 0;
   }
   .info > .info-title {
-    font-size: 2rem;
+    font-size: 3.2rem;
     line-height: 44.8px;
   }
   .info > .info-title > br {
     display: none;
   }
   .top-line {
-    padding-bottom: 0.75rem;
+    padding-bottom: 1.2rem;
   }
   .bottom-line {
-    font-size: 1.25rem;
-    padding-top: 1.25rem;
+    font-size: 2rem;
+    padding-top: 2rem;
     line-height: 21.6px;
   }
   #comment {
@@ -89,22 +89,22 @@
     display: block;
   }
   .copyright {
-    padding: 0 6.5rem;
+    padding: 0 10.4rem;
   }
 
   /* 로그인 회원가입 페이지 */
   #register-header {
-    margin-top: 3rem;
+    margin-top: 4.8rem;
   }
 }
 
 @media (max-width: 768px) {
   /* 메인 페이지 */
   #header {
-    padding: 0 1rem;
+    padding: 0 1.6rem;
   }
   .wrapper {
-    padding: 0 1rem;
+    padding: 0 1.6rem;
   }
   .logo {
     display: none;
@@ -126,16 +126,16 @@
     display: block;
   }
   .banner-title > .title {
-    font-size: 2rem;
-    padding-bottom: 1.125rem;
+    font-size: 3.2rem;
+    padding-bottom: 1.8rem;
   }
   .banner-title > .visit-btn {
     padding: 13.5px 33.5px;
     font-weight: 600;
-    font-size: 1rem;
+    font-size: 1.6rem;
   }
   #contents {
-    margin: 3.125rem 0 0 0;
+    margin: 5rem 0 0 0;
   }
   .item-list {
     flex-direction: column;
@@ -153,19 +153,19 @@
     padding: 0;
   }
   .info > .info-title {
-    font-size: 1.5rem;
+    font-size: 2.4rem;
     line-height: 33.6px;
   }
   .info > .info-title > br {
     display: none;
   }
   .top-line {
-    font-size: 1rem;
+    font-size: 1.6rem;
     padding-bottom: 0.5rem;
   }
   .bottom-line {
-    font-size: 1rem;
-    padding-top: 1.25rem;
+    font-size: 1.6rem;
+    padding-top: 2rem;
     line-height: 19.2px;
   }
   #comment {
@@ -173,17 +173,17 @@
     height: 540px;
   }
   .comment-title {
-    padding-top: 7.5rem;
+    padding-top: 12rem;
   }
   .comment-title > .title {
-    font-size: 2rem;
+    font-size: 3.2rem;
     line-height: 44.8px;
   }
   .copyright {
     display: grid;
     grid-template-rows: repeat(2, 1fr);
-    padding: 0 2rem;
-    gap: 3.75rem 0;
+    padding: 0 3.2rem;
+    gap: 6rem 0;
   }
   .copyright > p {
     grid-row: 2;
@@ -195,17 +195,17 @@
     grid-row: 1;
   }
   .footer {
-    padding: 2rem 0;
+    padding: 3.2rem 0;
   }
 
   /* 로그인, 회원가입 페이지 */
   #register-container {
-    max-width: 27rem;
-    padding: 0 1rem;
+    max-width: 43.2rem;
+    padding: 0 1.6rem;
   }
   #register-header {
-    margin-top: 1.5rem;
-    margin-bottom: 1.5rem;
+    margin-top: 2.4rem;
+    margin-bottom: 2.4em;
   }
   .register-logo {
     max-width: 262px;

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -4,7 +4,7 @@
   position: fixed;
   top: 0;
   width: 100%;
-  padding: 0 12.5rem;
+  padding: 0 20rem;
   z-index: 999;
   background: #fff;
   border-bottom: 1px solid #dfdfdf;
@@ -26,6 +26,7 @@
   display: inline-block;
   width: 42px;
   padding: 14.5px 43px;
+  font-size: 1.6rem;
   font-weight: 600;
   box-sizing: content-box;
   color: #ffffff;
@@ -62,7 +63,7 @@ main {
   overflow: hidden;
   background: url(../images/banner.png), #cfe5ff;
   background-repeat: no-repeat;
-  background-position: right calc(45% - 220px) bottom 0px;
+  background-position: right calc(48% - 220px) bottom 0px;
   height: 540px;
 }
 
@@ -149,7 +150,7 @@ main {
   overflow: hidden;
   background: url(../images/comment.png), #cfe5ff;
   background-repeat: no-repeat;
-  background-position: right calc(45% - 220px) bottom 0px;
+  background-position: right calc(48% - 220px) bottom 0px;
   height: 540px;
 }
 .comment {
@@ -165,7 +166,7 @@ main {
   z-index: 2;
 }
 .comment-title > .title {
-  font-size: 2.5rem;
+  font-size: 4rem;
   font-weight: 700;
   line-height: 56px;
   color: var(--color-gray700);
@@ -182,18 +183,20 @@ main {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 0 12.5rem;
+  padding: 0 20rem;
   color: #9ca3af;
   font-weight: 400;
 }
-
+.copyright > p {
+  font-size: 1.6rem;
+}
 .policy-list {
   display: flex;
   gap: 30px;
 }
 
 .policy-list > li > a {
-  font-size: 1rem;
+  font-size: 1.6rem;
   font-weight: 400;
   color: #e5e7eb;
 }

--- a/register/login.html
+++ b/register/login.html
@@ -32,9 +32,9 @@
             id="email"
             type="email"
             autofocus
+            required
             placeholder="이메일을 입력해주세요"
           />
-          <p class="error-msg">잘못된 이메일입니다.</p>
         </div>
         <div class="input-box">
           <label for="password">비밀번호</label>
@@ -43,10 +43,10 @@
               name="password"
               id="password"
               type="password"
+              required
               placeholder="비밀번호를 입력해주세요"
             />
-            <p class="error-msg">8자 이상 입력해 주세요.</p>
-            <span class="hide-btn" disabled></span>
+            <span class="hide-btn"></span>
           </div>
         </div>
         <div class="login-btn">

--- a/register/signup.html
+++ b/register/signup.html
@@ -32,9 +32,9 @@
             id="email"
             type="email"
             autofocus
+            required
             placeholder="이메일을 입력해주세요"
           />
-          <span class="error-msg">잘못된 이메일입니다.</span>
         </div>
         <div class="input-box">
           <label for="nickname">닉네임</label>
@@ -42,9 +42,9 @@
             name="nickname"
             id="nickname"
             type="text"
+            required
             placeholder="닉네임을 입력해주세요"
           />
-          <span class="error-msg">닉네임을 입력해 주세요.</span>
         </div>
         <div class="input-box">
           <label for="password">비밀번호</label>
@@ -53,9 +53,9 @@
               name="password"
               id="password"
               type="password"
+              required
               placeholder="비밀번호를 입력해주세요"
             />
-            <p class="error-msg">8장 이상 입력해 주세요.</p>
             <span class="hide-btn"></span>
           </div>
         </div>
@@ -66,9 +66,9 @@
               name="passwordCheck"
               id="passwordCheck"
               type="password"
+              required
               placeholder="비밀번호를 다시 한 번 입력해주세요"
             />
-            <p class="error-msg">비밀번호가 일치하지 않습니다.</p>
             <span class="hide-btn"></span>
           </div>
         </div>


### PR DESCRIPTION
## 요구사항

### 기본

**로그인**

- [x] 이메일 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “이메일을 입력해주세요.” 빨강색 에러 메세지를 보입니다.
- [x] 이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 경우 input에 빨강색 테두리와 아래에 “잘못된 이메일 형식입니다” 빨강색 에러 메세지를 보입니다.
- [x] 비밀번호 input에서 focus out 할 때, 값이 없을 경우 아래에 “비밀번호를 입력해주세요.” 에러 메세지를 보입니다
- [x] 비밀번호 input에서 focus out 할 때, 값이 8자 미만일 경우 아래에 “비밀번호를 8자 이상 입력해주세요.” 에러 메세지를 보입니다.
- [x] input 에 빈 값이 있거나 에러 메세지가 있으면 ‘로그인’ 버튼은 비활성화 됩니다.
- [x] input 에 유효한 값을 입력하면 ‘로그인' 버튼이 활성화 됩니다.
- [x] 활성화된 ‘로그인’ 버튼을 누르면 “/items” 로 이동합니다

**회원가입**

- [x]  이메일 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “이메일을 입력해주세요.” 빨강색 에러 메세지를 보입니다.
- [x]  이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 경우 input에 빨강색 테두리와 아래에 “잘못된 이메일 형식입니다” 빨강색 에러 메세지를 보입니다.
- [x]  닉네임 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “닉네임을 입력해주세요.” 빨강색 에러 메세지를 보입니다.
- [x]  비밀번호 input에서 focus out 할 때, 값이 없을 경우 아래에 “비밀번호를 입력해주세요.” 에러 메세지를 보입니다
- [x]  비밀번호 input에서 focus out 할 때, 값이 8자 미만일 경우 아래에 “비밀번호를 8자 이상 입력해주세요.” 에러 메세지를 보입니다.
- [x]  비밀번호 input과 비밀번호 확인 input의 값이 다른 경우, 비밀번호 확인 input 아래에 “비밀번호가 일치하지 않습니다..” 에러 메세지를 보입니다.
- [x]  input 에 빈 값이 있거나 에러 메세지가 있으면 ‘회원가입’ 버튼은 비활성화 됩니다.
- [x]  input 에 유효한 값을 입력하면 ‘회원가입' 버튼이 활성화 됩니다.
- [x]  활성화된 ‘회원가입’ 버튼을 누르면 “/signup” 로 이동합니다

### 심화

- [x] 눈 모양 아이콘 클릭시 비밀번호의 문자열이 보이기도 하고, 가려지기도 합니다.
- [x] 비밀번호의 문자열이 가려질 때는 눈 모양 아이콘에는 사선이 그어져있고, 비밀번호의 문자열이 보일 때는 사선이 없는 눈 모양 아이콘이 보이도록 합니다.

## 주요 변경사항

- 에러메세지를 html에서 input태그 아래에 p태그에 class로 display: none 속성을 줘서 관리를 했었는데 따로 errorMessage.js 파일을 만들어서 관리하고, validation.js에서 메세지를 생성하도록 바꾸었습니다.

## 스크린샷
![screencapture-sprint-fe8-kjh-netlify-app-register-login-2024-06-13-18_04_32](https://github.com/codeit-bootcamp-frontend/8-Sprint-Mission/assets/72942662/7e13bf59-cbfe-47a0-b478-d48d56ad4739)
![screencapture-sprint-fe8-kjh-netlify-app-register-login-2024-06-13-18_04_48](https://github.com/codeit-bootcamp-frontend/8-Sprint-Mission/assets/72942662/ff9f6930-a29e-495b-b38e-3869801516d1)
![screencapture-sprint-fe8-kjh-netlify-app-register-login-2024-06-13-18_04_55](https://github.com/codeit-bootcamp-frontend/8-Sprint-Mission/assets/72942662/482fb297-5c75-458b-b722-8e8d6c619c5f)


## 멘토에게
- [배포링크](https://sprint-fe8-kjh.netlify.app/) 입니다
- 에러 메시지가 존재하면 `input`태그에 `focus` 되어도 `outline`의 색이 빨강색이 유지가 되는 게 좋을까요?
- 눈 모양 아이콘 같은 경우 처음에` button`으로 했다가 지금은 `span`으로 바꾸고 `cursor` 속성을 `pointer`로 주었는데 `button`으로 하는 게 좋았을지 궁금합니다.
- 배포한 웹에는 로그인 화면에서만 `input`이벤트와 `blur`이벤트를 같이 줘서 `focus out` 에 만 아닌 입력 시에도 반응하게 해놓았는데 요구 사항에만 맞추는 게 좋을까요?? (push한 파일에는 요구 사항 대로만 코드가 있습니다.)
- 셀프 코드 리뷰를 통해 질문 이어가겠습니다.
