### PR TITLE
[강효성] Sprint4

### DIFF
--- a/login.html
+++ b/login.html
@@ -2,6 +2,8 @@
 <html lang="ko">
   <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta property="og:type" content="website" />
     <title>판다마켓_로그인</title>
     <link rel="stylesheet" as="style" crossorigin
       href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.min.css">

--- a/login.html
+++ b/login.html
@@ -13,19 +13,25 @@
 
   <body>
     <div class="logoSection">
-      <a href="/" class="topBigLogo"><img class="topBigLogoImg" src="img/top_big_logo.png" alt="판다마켓"></a>
+      <a href="/" class="topBigLogo" aria-label="홈으로 이동하기"><img class="topBigLogoImg" src="img/top_big_logo.png" alt="판다마켓"></a>
 
-      <form method="post">
+      <form id="loginForm" method="post">
         <div class="inputSection">
           <label for="email">이메일</label>
-          <input id="email" name="email" type="email" placeholder="이메일을 입력해 주세요">
+          <input id="email" name="email" type="email" placeholder="이메일을 입력해 주세요" required />
+          <span id="emailEmpty" class="errorMessage">이메일을 입력해 주세요</span>
+          <span id="emailWrong" class="errorMessage">잘못된 이메일 형식입니다</span>
         </div>
         <div class="inputSection">
           <label for="password">비밀번호</label>
           <div class="inputPassword">
-            <input id="password" name="password" type="password" placeholder="비밀번호를 입력해 주세요">
-            <img class="visibilityIcon" src="img/ic_password_visibility.png" alt="비밀번호 온오프">
+            <input id="password" name="password" type="password" placeholder="비밀번호를 입력해 주세요" required />
+            <button type="button" class="visibilityButton">
+              <img class="visibilityIcon" src="img/ic_password_visibility.png" alt="비밀번호 온오프">
+            </button>
           </div>
+          <span id="passwordEmpty" class="errorMessage">비밀번호를 입력해 주세요</span>
+          <span id="passwordWrong" class="errorMessage">비밀번호를 8자 이상 입력해 주세요</span>
         </div>
         <button type="submit" class="button inside widthFull">로그인</button>
       </form>
@@ -33,9 +39,9 @@
       <div class="simpleLogin">
         <h3>간편 로그인하기</h3>
         <div class="simpLoginWays">
-          <a href="https://www.google.com/" target="_blank"
+          <a href="https://www.google.com/" target="_blank" rel="noopener noreferrer" aria-label="구글 로그인"
             ><img class="simpLoginWay" src="img/google_logo.png" alt="구글 로그인"></a>
-          <a href="https://www.kakaocorp.com/page/" target="_blank"
+          <a href="https://www.kakaocorp.com/page/" target="_blank" rel="noopener noreferrer" aria-label="카톡 로그인"
             ><img class="simpLoginWay" src="img/cacao_logo.png" alt="카톡 로그인"></a>
         </div>
       </div>
@@ -43,5 +49,7 @@
         판다마켓이 처음이신가요? <a href="signup.html">회원가입</a>
       </div>
     </div>
+
+    <script src="scripts/sign.js"></script>
   </body>
 </html>

--- a/media.css
+++ b/media.css
@@ -17,16 +17,7 @@
     font-size: 18px;
     margin-bottom: 16px;
   }
-}
 
-@media (min-width: 1280px) {
-  .topBigLogo {
-    margin-top: 60px;
-    margin-bottom: 40px;
-  }
-}
-
-@media (min-width: 768px) {
   header {
     padding: 0 24px;
   }
@@ -49,23 +40,7 @@
     flex-basis: auto;
     order: 0;
   }
-}
 
-@media (min-width: 1280px) {
-  header {
-    padding: 0 200px;
-  }
-
-  .break-on-desktop {
-    display: inline;
-  }
-
-  footer {
-    padding: 32px 200px 108px 200px;
-  }
-}
-
-@media (min-width: 768px) {
   .banner {
     height: 90vh;
     background-size: 120%;
@@ -94,7 +69,7 @@
   }
 
   .content:nth-child(2) {
-    flex-direction: column-reverse;
+    flex-direction: row-reverse;
   }
 
   .contentText h1 {
@@ -109,6 +84,23 @@
 }
 
 @media (min-width: 1280px) {
+  .topBigLogo {
+    margin-top: 60px;
+    margin-bottom: 40px;
+  }
+
+  header {
+    padding: 0 200px;
+  }
+
+  .break-on-desktop {
+    display: inline;
+  }
+
+  footer {
+    padding: 32px 200px 108px 200px;
+  }
+
   .banner {
     text-align: left;
     height: 540px;
@@ -156,5 +148,9 @@
     font-size: 24px;
     line-height: 29px;
     margin-top: 24px;
+  }
+
+  .break-on-desktop {
+    display: inline;
   }
 }

--- a/sign.js
+++ b/sign.js
@@ -1,0 +1,41 @@
+const loginForm = document.getElementById("loginForm");
+const signupForm = document.getElementById("signupForm");
+const emailInput = document.getElementById("email");
+const nicknameInput = document.getElementById("nickname");
+const passwordInput = document.getElementById("password");
+const passwordConfirmationInput = document.getElementById("passwordConfirmation");
+const submitButton = document.querySelector('.logoSection form button[type="submit"]');
+
+function showError(input, errorId) {
+  const errorElement = document.getElementById(errorId);
+  errorElement.style.display = "block";
+  input.style.border = "1px solid #f74747";
+}
+
+function hideError(input, errorId) {
+  const errorElement = document.getElementById(errorId);
+  errorElement.style.display = "none";
+  input.style.border = "none";
+}
+
+function validateEmailString(email) {
+  const emailRegex = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$/;
+  return emailRegex.test(email);
+}
+
+function checkEmailValidity() {
+  const emailValue = emailInput.value.trim();
+  isEmailValid = false;
+  hideError(emailInput, "emailEmpty");
+  hideError(emailInput, "emailWrong");
+  if (!emailValue) {
+    showError(emailInput, "emailEmpty");
+  } else if (!validateEmailString(emailValue)) {
+    showError(emailInput, "emailWrong");
+  } else {
+    isEmailValid = true;
+    hideError(emailInput, "emailEmpty");
+    hideError(emailInput, "emailWrong");
+    updateSubmitButtonState();
+  }
+}

--- a/signup.html
+++ b/signup.html
@@ -2,6 +2,8 @@
 <html lang="ko">
   <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta property="og:type" content="website" />
     <title>판다마켓_회원가입</title>
     <link rel="stylesheet" as="style" crossorigin
       href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.min.css">

--- a/signup.html
+++ b/signup.html
@@ -13,30 +13,41 @@
 
   <body>
     <div class="logoSection">
-      <a href="/" class="topBigLogo"><img class="topBigLogoImg" src="img/top_big_logo.png" alt="판다마켓"></a>
+      <a href="/" class="topBigLogo" aria-label="홈으로 이동하기"><img class="topBigLogoImg" src="img/top_big_logo.png" alt="판다마켓"></a>
 
-      <form method="post">
+      <form id="signupForm" method="post">
         <div class="inputSection">
           <label for="email">이메일</label>
-          <input id="email" name="email" type="email" placeholder="이메일을 입력해 주세요">
+          <input id="email" name="email" type="email" placeholder="이메일을 입력해 주세요" required />
+          <span id="emailEmpty" class="errorMessage">이메일을 입력해 주세요</span>
+          <span id="emailWrong" class="errorMessage">잘못된 이메일 형식입니다</span>
         </div>
         <div class="inputSection">
           <label for="nickname">닉네임</label>
-          <input id="nickname" name="nickname" type="txt" placeholder="닉네임을 입력해 주세요">
+          <input id="nickname" name="nickname" type="text" placeholder="닉네임을 입력해 주세요" required />
+          <span id="nicknameEmpty" class="errorMessage">닉네임을 입력해 주세요</span>
         </div>
         <div class="inputSection">
           <label for="password">비밀번호</label>
           <div class="inputPassword">
-            <input id="password" name="password" type="password" placeholder="비밀번호를 입력해 주세요">
-            <img class="visibilityIcon" src="img/ic_password_visibility.png" alt="비밀번호 온오프">
+            <input id="password" name="password" type="password" placeholder="비밀번호를 입력해 주세요" required />
+            <button type="button" class="visibilityButton">
+              <img class="visibilityIcon" src="img/ic_password_visibility.png" alt="비밀번호 온오프">
+            </button>
           </div>
+          <span id="passwordEmpty" class="errorMessage">비밀번호를 입력해 주세요</span>
+          <span id="passwordWrong" class="errorMessage">비밀번호를 8자 이상 입력해 주세요</span>
         </div>
         <div class="inputSection">
-          <label for="passwordCheck">비밀번호</label>
+          <label for="passwordCheck">비밀번호 확인</label>
           <div class="inputPassword">
-            <input id="passwordCheck" name="passwordCheck" type="passwordCheck" placeholder="비밀번호를 다시 한 번 입력해 주세요">
-            <img class="visibilityIcon" src="img/ic_password_visibility.png" alt="비밀번호 온오프">
+            <input id="passwordCheck" name="passwordCheck" type="passwordCheck" placeholder="비밀번호를 다시 한 번 입력해 주세요" required />
+            <button type="button" class="visibilityButton">
+              <img class="visibilityIcon" src="img/ic_password_visibility.png" alt="비밀번호 온오프">
+            </button>
           </div>
+          <span id="passwordFulfillConditions" class="errorMessage">먼저 조건에 맞는 비밀번호를 입력해 주세요</span>
+          <span id="passwordNotSame" class="errorMessage">비밀번호가 일치하지 않습니다</span>
         </div>
         <button type="submit" class="button inside widthFull">회원가입</button>
       </form>
@@ -44,9 +55,9 @@
       <div class="simpleLogin">
         <h3>간편 로그인하기</h3>
         <div class="simpLoginWays">
-          <a href="https://www.google.com/" target="_blank"
+          <a href="https://www.google.com/" target="_blank" rel="noopener noreferrer" aria-label="구글 로그인"
             ><img class="simpLoginWay" src="img/google_logo.png" alt="구글 로그인"></a>
-          <a href="https://www.kakaocorp.com/page/" target="_blank"
+          <a href="https://www.kakaocorp.com/page/" target="_blank" rel="noopener noreferrer" aria-label="카톡 로그인"
             ><img class="simpLoginWay" src="img/cacao_logo.png" alt="카톡 로그인"></a>
         </div>
       </div>
@@ -56,5 +67,7 @@
         </div>
       </div>
     </div>
+
+    <script src="scripts/sign.js"></script>
   </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -151,7 +151,7 @@ main {
   margin-top: 20px;
 }
 
-#reverseContent {
+.content:nth-child(2) {
   text-align: right;
 }
 
@@ -163,6 +163,7 @@ footer {
   background-color: var(--footer-bg-color);
   color: var(--footer-bs-txt-color);
   display: flex;
+  flex-wrap: wrap;
   justify-content: space-between;
   align-items: center;
   padding: 32px;


### PR DESCRIPTION
## 요구사항

### 기본

- [x] Github에 PR(Pull Request)을 만들어서 미션을 제출합니다.
- [x] 피그마 디자인에 맞게 페이지를 만들어 주세요.
- [x] React와 같은 UI 라이브러리를 사용하지 않고 진행합니다.

### 로그인

- [ ] 이메일 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “이메일을 입력해주세요.” 빨강색 에러 메세지를 보입니다.
- [ ] 이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 경우 input에 빨강색 테두리와 아래에 “잘못된 이메일 형식입니다” 빨강색 에러 메세지를 보입니다.
- [ ] 비밀번호 input에서 focus out 할 때, 값이 없을 경우 아래에 “비밀번호를 입력해주세요.” 에러 메세지를 보입니다
- [ ] 비밀번호 input에서 focus out 할 때, 값이 8자 미만일 경우 아래에 “비밀번호를 8자 이상 입력해주세요.” 에러 메세지를 보입니다.
- [ ] input 에 빈 값이 있거나 에러 메세지가 있으면 ‘로그인’ 버튼은 비활성화 됩니다.
- [ ] input 에 유효한 값을 입력하면 ‘로그인' 버튼이 활성화 됩니다.
- [ ] 활성화된 ‘로그인’ 버튼을 누르면 “/items” 로 이동합니다

### 회원가입

- [ ] 이메일 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “이메일을 입력해주세요.” 빨강색 에러 메세지를 보입니다.
- [ ] 이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 경우 input에 빨강색 테두리와 아래에 “잘못된 이메일 형식입니다” 빨강색 에러 메세지를 보입니다.
- [ ] 닉네임 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “닉네임을 입력해주세요.” 빨강색 에러 메세지를 보입니다.
- [ ] 비밀번호 input에서 focus out 할 때, 값이 없을 경우 아래에 “비밀번호를 입력해주세요.” 에러 메세지를 보입니다
- [ ] 비밀번호 input에서 focus out 할 때, 값이 8자 미만일 경우 아래에 “비밀번호를 8자 이상 입력해주세요.” 에러 메세지를 보입니다.
- [ ] 비밀번호 input과 비밀번호 확인 input의 값이 다른 경우, 비밀번호 확인 input 아래에 “비밀번호가 일치하지 않습니다..” 에러 메세지를 보입니다.
- [ ] input 에 빈 값이 있거나 에러 메세지가 있으면 ‘회원가입’ 버튼은 비활성화 됩니다.
- [ ] input 에 유효한 값을 입력하면 ‘회원가입' 버튼이 활성화 됩니다.
- [ ] 활성화된 ‘회원가입’ 버튼을 누르면 “/signup” 로 이동합니다

## 심화

- [ ] 눈 모양 아이콘 클릭시 비밀번호의 문자열이 보이기도 하고, 가려지기도 합니다.
- [ ] 비밀번호의 문자열이 가려질 때는 눈 모양 아이콘에는 사선이 그어져있고, 비밀번호의 문자열이 보일 때는 사선이 없는 눈 모양 아이콘이 보이도록 합니다.


### 주요 변경사항

- login.html 파일과 signup.html 파일을 수정했습니다.
- js 파일은 아직 완성하지 못했습니다.

### 멘토에게

- 이메일 정규표현식을 검색하니 표현식의 형태가 조금씩 달랐습니다. 혹시 가장 권장되는 형태가 있나요?
- 셀프 코드 리뷰를 통해 질문 이어가겠습니다.
